### PR TITLE
feat: add global notice comp

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -3,6 +3,11 @@
 // global app config
 export default defineAppConfig({
   dateFormat: 'MMM DD, YYYY',
+  notice: {
+    text: 'Join our Halloween Hackathon 2024! $6666 in DEVILISH prizes up for grabs. Apply before the 13th of October!',
+    href: 'https://hackathon.storacha.network',
+    displayUntil: '2024-10-14', // use ISO date format or final day +1 in yyyy-mm-dd
+  },
   actions: {
     start: { text: 'Start Storing', href: 'https://console.storacha.network/' },
     docs: { text: 'Docs', href: 'https://docs.storacha.network' },

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -65,6 +65,7 @@ function toggleMobileMenu() {
     ]"
     v-bind="$attrs"
   >
+    <Notice v-bind="useAppConfig().notice" />
     <div class="grid-margins h-20 flex items-center justify-between transition-all">
       <AppLink class="ident transition" href="/" title="">
         <Ident :site-name="siteName" class="ident h-10 translate-x--1rem" :invert="nav.mobileActive" />

--- a/components/Notice.vue
+++ b/components/Notice.vue
@@ -14,7 +14,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="isVisible" class="bg-brand-3 p-3 text-center text-base text-sm text-brand-4">
+  <div v-if="isVisible" class="bg-brand-3 p-3 text-center text-sm text-brand-4">
     <AppLink :href="href" class="block w-full">
       {{ text }} <AppIcon i="i-carbon:arrow-right" class="inline-block" />
     </AppLink>

--- a/components/Notice.vue
+++ b/components/Notice.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+interface NoticeProps {
+  displayUntil: string
+  text: string
+  href: string
+}
+
+const props = defineProps<NoticeProps>()
+const isVisible = ref(false)
+
+onMounted(() => {
+  isVisible.value = new Date(props.displayUntil).getTime() > Date.now()
+})
+</script>
+
+<template>
+  <div v-if="isVisible" class="bg-brand-3 p-3 text-center text-base text-sm text-brand-4">
+    <AppLink :href="href" class="block w-full">
+      {{ text }} <AppIcon i="i-carbon:arrow-right" class="inline-block" />
+    </AppLink>
+  </div>
+</template>


### PR DESCRIPTION
Adds a global notice component to the app with configurable end date and text.

- displayed at the top of the viewport
- whole banner is a click target with single action
- visible until the configured date has passed

Setup using: `app.config.ts` to enable the display.

example:
```js
notice: {
    text: 'Join our Halloween Hackathon 2024! $6666 in DEVILISH prizes up for grabs. Apply before the 13th of October!',
    href: 'https://hackathon.storacha.network',
    displayUntil: '2024-10-14', // use ISO date format or final day +1 in yyyy-mm-dd
  },
```

![notice](https://github.com/user-attachments/assets/223a06ee-f44a-47f1-b465-931723851e1c)

ref: #65 