### PR TITLE
fix: useRuntimeConfig() to load console env

### DIFF
--- a/components/ReferralCodeCreator.vue
+++ b/components/ReferralCodeCreator.vue
@@ -3,19 +3,20 @@ export interface ReferralCodeCreatorProps {
   referralsUrl: string
 }
 
-const referralsUrl =  `${process.env.VUE_APP_CONSOLE_URL}/referrals`
+const config = useRuntimeConfig()
+const referralsUrl = `${config.public.consoleUrl}/referrals`
 </script>
 
 <template>
   <div>
-    <div class="prose p1 color-brand-3">
+    <div class="color-brand-3 prose p1">
       <p>
         <b>Enter your email</b> and we will generate your unique referral code!
       </p>
     </div>
     <form :action="referralsUrl" method="GET" class="flex flex-row space-x-4">
-      <input type="email" name="email" class="rounded-full px-4 w-96" placeholder="Email Address" />
-      <input type="submit" value="Generate Code" class="btn " />
+      <input type="email" name="email" class="w-96 rounded-full px-4" placeholder="Email Address">
+      <input type="submit" value="Generate Code" class="btn">
     </form>
   </div>
 </template>

--- a/components/ReferredButton.vue
+++ b/components/ReferredButton.vue
@@ -3,14 +3,14 @@ export interface ReferralCodeCreatorProps {
   referralsUrl: string
 }
 const route = useRoute()
+const config = useRuntimeConfig()
 const refcode = route.query.refcode
-const consoleSignupUrl =  `${process.env.VUE_APP_CONSOLE_URL}?refcode=${refcode}`
-
+const consoleSignupUrl = `${config.public.consoleUrl}?refcode=${refcode}`
 </script>
 
 <template>
   <div>
-    <div class="prose p1 color-brand-3">
+    <div class="color-brand-3 prose p1">
       <p>
         For the full rundown on how it all works, check out our <b><a href="TODOtoslink">Terms & Conditions</a></b>.
       </p>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -91,6 +91,7 @@ export default defineNuxtConfig({
     public: {
       // feed URL used for /api/blog
       blogFeedUrl: 'https://medium.com/feed/@storacha',
+      consoleUrl: import.meta.env.NUXT_PUBLIC_CONSOLE_URL || 'https://console.storacha.network',
     },
   },
 


### PR DESCRIPTION
fix for #81 to load the runtime env correctly without exposing the process env to the client