### PR TITLE
docs: added "medium" and "extra spicy" as plan descriptors

### DIFF
--- a/pages/referred.vue
+++ b/pages/referred.vue
@@ -12,7 +12,7 @@ const consoleSignupUrl = `${config.public.consoleUrl}?refcode=${refcode}`
         <template #right>
           <SectionHeader class="color-brand-3" eyebrow="A Master Racha Invited You"
             title="Receive up to Two Months of Free Storage"
-            description="Sign up now for a Lite plan and receive two months subscription free. Sign up to a Business plan and receive one month subscription for free. Continue using Storacha so both of you earn even more!" />
+            description="Sign up now for a Lite/Medium plan and receive two months subscription free. Sign up to a Business/Extra Spicy plan and receive one month subscription for free. Continue using Storacha so both of you earn even more!" />
           <div class="color-brand-3 prose">
             <p>
               For the full rundown on how it all works, check out our <b><a href="https://docs.storacha.network/referral-terms/">Terms &


### PR DESCRIPTION
We have multiple names for the same plan so I changed Lite to "Lite/Medium" and Business to "Business/Extra Spicy" to offer some clarity.

The solution might be fixing this directly in Stripe so that we have capsaicin-relevant plan descriptors; however, this will likely impact the web3.storage sign up flow.