### PR TITLE
fix: break-words on blog snippet

### DIFF
--- a/components/Blog/Card.vue
+++ b/components/Blog/Card.vue
@@ -29,7 +29,7 @@ defineProps<{
           <time class="h5 text-sm" :datetime="item.pubDate">
             {{ useAppDateFormat(item.pubDate) }}
           </time>
-          <p v-if="showSnippet" class="text-base p1">
+          <p v-if="showSnippet" class="text-base p1 break-words">
             {{ item.snippet }}
           </p>
         </div>


### PR DESCRIPTION
Before:

<img width="408" alt="Screenshot 2025-01-31 at 10 19 29" src="https://github.com/user-attachments/assets/4d731e24-88ed-4065-ae14-d29ddb6827e7" />

After:

<img width="414" alt="Screenshot 2025-01-31 at 10 19 21" src="https://github.com/user-attachments/assets/4a3a15cc-4bef-497b-a3ea-5dca8ef8a46a" />

