### PR TITLE
fix: better error handling when pulling blog posts

### DIFF
--- a/components/Blog/Cell.vue
+++ b/components/Blog/Cell.vue
@@ -1,7 +1,10 @@
 <script lang="ts" setup>
-const { data: blog } = await useLazyFetch('/api/blog')
+const { data: blog, error } = await useLazyFetch('/api/blog')
+if (error.value) {
+  console.error(error.value)
+}
 // limit to 2 blog items
-const items = computed(() => blog.value?.items.slice(0, 2))
+const items = error.value ? [] : computed(() => blog.value?.items.slice(0, 2))
 </script>
 
 <template>


### PR DESCRIPTION
Attempt to fix this:

<img width="702" alt="Screenshot 2025-02-20 at 3 07 57 PM" src="https://github.com/user-attachments/assets/560e6016-3445-4e91-bfe4-4e4da2a2b828" />

As far as I can tell, errors fetching `/api/blog` are causing 500s when Google tries to crawl the homepage. Try to do a little error handling in an attempt to prevent this:

<img width="384" alt="Screenshot 2025-02-20 at 3 09 14 PM" src="https://github.com/user-attachments/assets/3cfbb5a0-f34a-48cd-b421-de7bc9d3d8f4" />


I'm a little worried because behavior locally was very strange - I tried to get the server API to simply error but I saw the page rendering a non-error. This may be caching, in which case I hope it goes away in staging and prod.