### PR TITLE
fix: discrepancies in tier names

### DIFF
--- a/components/Pricing.vue
+++ b/components/Pricing.vue
@@ -17,7 +17,7 @@ const start = useActions('start')
       />
       <div class="grid grid-cols-1 mb-50 mt-12 gap-4 sm:grid-cols-3">
         <PricingCard
-          tier="Mild"
+          tier="Starter"
           price="0"
           unit="mo"
           icon="🌶"
@@ -28,7 +28,7 @@ const start = useActions('start')
           :action="start"
         />
         <PricingCard
-          tier="Medium"
+          tier="Lite"
           price="10"
           unit="mo"
           icon="🌶🌶"
@@ -39,7 +39,7 @@ const start = useActions('start')
           :action="start"
         />
         <PricingCard
-          tier="Extra Spicy"
+          tier="Business"
           price="100"
           unit="mo"
           icon="🌶🌶🌶"

--- a/components/PricingCard.vue
+++ b/components/PricingCard.vue
@@ -2,7 +2,7 @@
 import type { BtnProps } from './Btn.vue'
 
 interface PricingCardProps {
-  tier: 'Mild' | 'Medium' | 'Extra Spicy'
+  tier: 'Starter' | 'Lite' | 'Business'
   price: string
   features: [string, string?][]
   unit: 'mo' | 'yr'

--- a/components/ReferralPricing.vue
+++ b/components/ReferralPricing.vue
@@ -17,7 +17,7 @@ const start = useActions('start')
       />
       <div class="grid grid-cols-1 mb-50 mt-12 gap-4 sm:grid-cols-3">
         <PricingCard
-          tier="Mild"
+          tier="Starter"
           price="0"
           unit="mo"
           icon="🌶"
@@ -27,7 +27,7 @@ const start = useActions('start')
           ]"
         />
         <PricingCard
-          tier="Medium"
+          tier="Lite"
           price="10"
           unit="mo"
           icon="🌶🌶"
@@ -37,7 +37,7 @@ const start = useActions('start')
           ]"
         />
         <PricingCard
-          tier="Extra Spicy"
+          tier="Business"
           price="100"
           unit="mo"
           icon="🌶🌶🌶"


### PR DESCRIPTION
This PR standardizes the tier names across the website. Previously, we used "mild, medium, spicy" on the pricing page, while "starter, lite, business" appeared elsewhere (Stripe, SLA, docs, etc.). This update ensures consistency by aligning all instances with the "starter, lite, business" naming convention.

Closes #42 .