### PR TITLE
Increased touch area for social media icons

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -5,12 +5,12 @@ const { getStarted, resources } = useActions('footerLinks')
 <template>
   <footer class="bg-brand-4 color-brand-3">
     <div class="border-3 b-current rounded-10 px-6 py-5 md:rounded-20 md:pt-12">
-      <div class="grid cols-1 gap-6 text-xs lg:cols-3 sm:cols-2 sm:text-base">
+      <div class="grid cols-1 gap-6 text-xs lg:grid-cols-[auto_1fr_auto] md:cols-[auto_1fr] sm:text-base">
         <div class="header">
           <MailingListSignup />
         </div>
-        <div class="flex text-1.2em lg:justify-center">
-          <SocialNetworks class="items-center" icon-class="hover:color-brand-1 hover:scale-110" />
+        <div class="flex justify-start text-1.2em md:justify-center">
+          <SocialNetworks class="lg:justify-center" icon-class="hover:color-brand-1 hover:scale-110" />
         </div>
         <div>
           <div class="grid cols-1 gap-6 lg:cols-2">

--- a/components/SocialNetworks.vue
+++ b/components/SocialNetworks.vue
@@ -7,7 +7,7 @@ const socialNetworks = useActions('socialNetworks')
 </script>
 
 <template>
-  <div class="h-fit flex flex-wrap justify-center gap-4">
+  <div class="h-fit flex flex-wrap gap-4">
     <div v-for="n in socialNetworks" :key="n.name">
       <AppLink
         :href="n.href"


### PR DESCRIPTION
## Description

Tagging @cwaring and @alanshaw for visibility :)

As per [dogfooding report](https://www.notion.so/filecoin/Storacha-Network-Report-12f7631f28258088b375d2f874dcb5f3), mobile touch targets for social icons should be increased to 48x48 pixels, meeting WCAG accessibility standards. 

## Screenshot
![Screenshot 2025-03-31 at 11 43 47](https://github.com/user-attachments/assets/e6c574a5-8111-4305-92c9-636b9ce5406a)
![Screenshot 2025-03-31 at 11 44 00](https://github.com/user-attachments/assets/0d68b2fa-685d-414b-9892-0e64f5ecc846)
