### PR TITLE
Fix/plausible utm tracking

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -187,7 +187,6 @@ export default defineNuxtConfig({
   plausible: {
     domain: 'storacha.network',
     autoOutboundTracking: true,
-    logIgnoredEvents: process.env.NODE_ENV === 'development',
   },
 
   unocss: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -185,7 +185,9 @@ export default defineNuxtConfig({
   },
 
   plausible: {
+    domain: 'storacha.network',
     autoOutboundTracking: true,
+    logIgnoredEvents: process.env.NODE_ENV === 'development',
   },
 
   unocss: {


### PR DESCRIPTION
Solution to #195 
  - Added `domain: 'storacha.network'` to Plausible configuration

Testing
  - Verified POST requests to `plausible.io/api/event` return 202 Accepted
  - Confirmed payload includes `"d": "storacha.network"` (previously empty)
  - Verified UTM parameters are included in event payload

Cannot verify in Plausible dashboard as I don't have account access. The 202 Accepted response confirms events are being received correctly. 

Note: UTM parameters only register when starting a new session (30-minute timeout), explaining the "occasional anomaly" behavior in the issue